### PR TITLE
fix 'Use of uninitialized value $IO::Socket::Socks::ISA[1]'

### DIFF
--- a/lib/IO/Socket/Socks.pm
+++ b/lib/IO/Socket/Socks.pm
@@ -1910,7 +1910,7 @@ sub STORE {
 
 	$self->{v} = $class;
 	eval "use $class; 1" or die $@;
-	$IO::Socket::Socks::ISA[1] = $class;
+	splice(@IO::Socket::Socks::ISA, 1, 1, $class);
 }
 
 sub UNTIE {


### PR DESCRIPTION
This line can be considered semantically equivalent to the original one, but without the warning.
